### PR TITLE
config file

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # This folder
-T_FOLDER="/root"
+CWD=$(pwd)
+CONFIG_FILE="${CWD}/backup.config"
 
 # Remote folder
 R_FOLDER="/server.com"
@@ -10,27 +11,25 @@ R_FOLDER="/server.com"
 SITES_DIR="/var/www"
 
 # MySQL settings
-USER="root"
-PASSWORD="mysqlpassword"
 MYSQLDUMP="/usr/bin/mysqldump"
 MYSQL="/usr/bin/mysql"
 
 # MySQL databases
-databases=`$MYSQL --user=$USER --password=$PASSWORD -e "SHOW DATABASES;" |\
+databases=`$MYSQL --defaults-extra-file=$CONFIG_FILE -e "SHOW DATABASES;" |\
 grep -Ev "(Database|information_schema)" |\
 grep -Ev "(Database|performance_schema)" |\
 grep -Ev "(Database|mysql)"`
 
 # For each db
 for db in $databases; do
-    $MYSQLDUMP --force --opt --lock-tables=false --user=$USER --password=$PASSWORD \
+    $MYSQLDUMP --force --opt --lock-tables=false --defaults-extra-file=$CONFIG_FILE \
     --databases $db | gzip > "$db.sql.gz"
 
     # Upload to Dropbox
-    /bin/bash $T_FOLDER/dropbox_uploader.sh upload $db.sql.gz $R_FOLDER/mysql/
+    /bin/bash $CWD/dropbox_uploader.sh upload $db.sql.gz $R_FOLDER/mysql/
 
     # Remove temp backup
-    /bin/rm -f $T_FOLDER/$db.sql.gz
+    /bin/rm -f $CWD/$db.sql.gz
 done
 
 ## Files backup
@@ -38,21 +37,21 @@ for i in `ls $SITES_DIR`; do
     tar czf $i.tar.gz --exclude-vcs $SITES_DIR/$i
 
     # Upload to Dropbox
-    /bin/bash $T_FOLDER/dropbox_uploader.sh upload $i.tar.gz $R_FOLDER/www/
+    /bin/bash $CWD/dropbox_uploader.sh upload $i.tar.gz $R_FOLDER/www/
 
     # Remove temp backup
-    /bin/rm -f $T_FOLDER/$i.tar.gz
+    /bin/rm -f $CWD/$i.tar.gz
 done
 
 ## Conf backup
 tar czf etc.tar.gz /etc
-/bin/bash $T_FOLDER/dropbox_uploader.sh upload etc.tar.gz $R_FOLDER/
-/bin/rm -f $T_FOLDER/etc.tar.gz
+/bin/bash $CWD/dropbox_uploader.sh upload etc.tar.gz $R_FOLDER/
+/bin/rm -f $CWD/etc.tar.gz
 
 ## Logs backup
 tar czf log.tar.gz /var/log
-/bin/bash $T_FOLDER/dropbox_uploader.sh upload log.tar.gz $R_FOLDER/
-/bin/rm -f $T_FOLDER/log.tar.gz
+/bin/bash $CWD/dropbox_uploader.sh upload log.tar.gz $R_FOLDER/
+/bin/rm -f $CWD/log.tar.gz
 
 # Remove users log
 rm /var/www/*/logs/*.log


### PR DESCRIPTION
Suppress MySQL warnings by storing user credentials in config file. Working directory must contain a backup.config with contents:
```
[client]
user=root
password=verycoolpassword
host=localhost
```
